### PR TITLE
[android] remove android:allowBackup from AndroidManifest.xml

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
 
     <application
         android:name=".PhotoApp"
-        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">


### PR DESCRIPTION
I am seeing this error on my build when setting backup to false:
```
* What went wrong:
Execution failed for task ':app:processReleaseManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:21:5-32
  	is also present at [me.relex:photodraweeview:1.0.0] AndroidManifest.xml:10:9-35 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:19:3-136:17 to override.
```