### PR TITLE
Fix Method getScale

### DIFF
--- a/photodraweeview/src/main/java/me/relex/photodraweeview/Attacher.java
+++ b/photodraweeview/src/main/java/me/relex/photodraweeview/Attacher.java
@@ -122,9 +122,7 @@ public class Attacher implements IAttacher, View.OnTouchListener, OnScaleDragGes
     }
 
     @Override public float getScale() {
-        return (float) Math.sqrt(
-                (float) Math.pow(getMatrixValue(mMatrix, Matrix.MSCALE_X), 2) + (float) Math.pow(
-                        getMatrixValue(mMatrix, Matrix.MSKEW_Y), 2));
+        return getMatrixValue(mMatrix, Matrix.MSCALE_X);
     }
 
     @Override public void setScale(float scale) {


### PR DESCRIPTION
The getScale method should use the two elements MSCALE_X and MSCALE_Y in the matrix, but usually the two are equal, so I only used one of them.